### PR TITLE
Merge Domain model into User model

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,11 +3,7 @@ from sqlobject import AND
 import models
 
 def get_or_create_domain(name):
-	try:
-		domain = models.Domain.select(models.Domain.q.name==name)[0]
-	except IndexError:
-		domain = models.Domain(name=name)
-	return domain
+	return name
 
 def get_or_create_user(name, domain):
 	try:

--- a/app.py
+++ b/app.py
@@ -11,7 +11,6 @@ from flask import url_for
 from sqlobject import AND
 
 from models import connect
-from models import Domain
 from models import Mail
 from models import User
 import settings
@@ -21,7 +20,7 @@ app = Flask(__name__)
 @app.route("/")
 def welcome():
 	try:
-		domains = list(Domain.select())
+		domains = settings.MY_DOMAINS
 	except IndexError:
 		domains = []
 	about = settings.ABOUT
@@ -43,7 +42,7 @@ def app_redirect():
 @app.route("/<user>/")
 def list_mail(user, domain=settings.MY_DOMAINS[0]):
 	try:
-		mails = list(Mail.select(Mail.q.user==User.select(AND(User.q.name==user, Domain.q.name==domain))[0]))
+		mails = list(Mail.select(Mail.q.user==User.select(AND(User.q.name==user, User.q.domain==domain))[0]))
 	except IndexError:
 		mails = []
 	return render_template('list_mail.html', **locals())
@@ -52,7 +51,7 @@ def list_mail(user, domain=settings.MY_DOMAINS[0]):
 @app.route("/<user>/<int:mail_id>/")
 def show_mail(user, mail_id, domain=settings.MY_DOMAINS[0]):
 	try:
-		mail = list(Mail.select(AND(Mail.q.user==User.select(AND(User.q.name==user, Domain.q.name==domain))[0],
+		mail = list(Mail.select(AND(Mail.q.user==User.select(AND(User.q.name==user, User.q.domain==domain))[0],
 									Mail.q.id==mail_id)))[0]
 	except IndexError:
 		abort(404)
@@ -67,7 +66,7 @@ def show_mail(user, mail_id, domain=settings.MY_DOMAINS[0]):
 @app.route("/<user>/<int:mail_id>/delete/")
 def delete_mail(user, mail_id, domain=settings.MY_DOMAINS[0]):
 	try:
-		mail = list(Mail.select(AND(Mail.q.user==User.select(AND(User.q.name==user, Domain.q.name==domain))[0],
+		mail = list(Mail.select(AND(Mail.q.user==User.select(AND(User.q.name==user, User.q.domain==domain))[0],
 									Mail.q.id==mail_id)))[0]
 	except IndexError:
 		abort(404)

--- a/models.py
+++ b/models.py
@@ -5,12 +5,9 @@ from settings import DB_URI
 def connect():
 	sqlhub.processConnection = connectionForURI(DB_URI)
 
-class Domain(SQLObject):
-	name = UnicodeCol(length=64, unique=True)
-
 class User(SQLObject):
-	name = UnicodeCol(length=64, unique=True)
-	domain = ForeignKey('Domain')
+	name = UnicodeCol(length=64)
+	domain = UnicodeCol(length=64)
 
 class Mail(SQLObject):
 	user = ForeignKey('User')
@@ -30,7 +27,6 @@ class Mail(SQLObject):
 if __name__ == "__main__":
 	connect()
 	print "Creating tables..."
-	Domain.createTable()
 	User.createTable()
 	Mail.createTable()
 	print "Done."

--- a/smtpd.py
+++ b/smtpd.py
@@ -12,7 +12,6 @@ from settings import MY_DOMAINS
 from settings import SMTPD_HOST
 from settings import SMTPD_PORT
 from models import connect
-from models import Domain
 from models import Mail
 from models import User
 from __init__ import get_or_create_domain

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -12,7 +12,7 @@
 	{%- if domains|length > 1 -%}
 		<select name="domain">
 		{%- for domain in domains -%}
-			<option>{{domain.name}}</option>
+			<option>{{domain}}</option>
 		{%- endfor -%}
 		</select>
 	{%- else -%}


### PR DESCRIPTION
Fix #4 
If two users belongs to different domains are different, then why not take `domain` as a property of user?

By the way, there are still some issues on the sql object. So far, my patch seems to save all emails with same username **with different domains** under one user entry, although by `get_or_create_user` it should create a new one. the mail list page merely filter the mail from current domain, according to the mail id.
